### PR TITLE
🔀 :: (#14) Dependency 업데이트

### DIFF
--- a/build-logic/src/main/kotlin/com/skogkatt/alio/ComposeAndroid.kt
+++ b/build-logic/src/main/kotlin/com/skogkatt/alio/ComposeAndroid.kt
@@ -4,7 +4,7 @@ import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
 
-internal fun Project.configureComposeAndroid(commonExtension: CommonExtension<*, *, *, *, *>) {
+internal fun Project.configureComposeAndroid(commonExtension: CommonExtension<*, *, *, *, *, *>) {
     commonExtension.apply {
         buildFeatures {
             compose = true

--- a/build-logic/src/main/kotlin/com/skogkatt/alio/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/com/skogkatt/alio/KotlinAndroid.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, *, *, *, *>) {
+internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, *, *, *, *, *>) {
     commonExtension.apply {
         compileSdk = 34
 

--- a/core/network/src/main/java/com/skogkatt/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/skogkatt/network/di/NetworkModule.kt
@@ -1,6 +1,5 @@
 package com.skogkatt.network.di
 
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.skogkatt.network.BuildConfig
 import dagger.Module
 import dagger.Provides
@@ -10,6 +9,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import javax.inject.Singleton
 
 @Module

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,18 @@
 [versions]
-androidGradlePlugin = "8.2.2"
-androidxCore = "1.12.0"
+androidGradlePlugin = "8.4.0"
+androidxCore = "1.13.1"
 androidxAppCompat = "1.6.1"
-androidxActivity = "1.8.2"
-androidxComposeBom = "2024.02.00"
-androidxComposeCompiler = "1.5.9"
+androidxActivity = "1.9.0"
+androidxComposeBom = "2024.05.00"
+androidxComposeCompiler = "1.5.14"
 kotlinxSerializationJson = "1.6.3"
-kotlin = "1.9.22"
-ktlint = "12.1.0"
-hilt = "2.50"
-ksp = "1.9.23-1.0.19"
+kotlin = "1.9.24"
+ktlint = "12.1.1"
+hilt = "2.51.1"
+ksp = "1.9.24-1.0.20"
 
 okhttp = "4.12.0"
-retrofit = "2.9.0"
-retrofitKotlinxSerialization = "1.0.0"
+retrofit = "2.11.0"
 
 junit = "4.13.2"
 androidxTestExt = "1.1.5"
@@ -39,7 +38,7 @@ hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-p
 
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerialization" }
+retrofit-kotlin-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 15 10:29:58 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### 💡 개요
- 프로젝트에서 사용중인 Dependency 최신화

### 📃 작업 내용
- androidGradlePlugin 8.2.2 -> 8.4.0
- androidCore 1.12.0 -> 1.13.1
- androidxActivity 1.8.2 -> 1.9.0
- androidxComposeBom 2024.02.00 -> 2024.05.00
- kotlin 1.9.22 -> 1.9.24
- ktlint 12.1.0 -> 12.1.1
- hilt 2.50 -> 2.51.1
- ksp 1.9.23-1.0.19 -> 1.9.24-1.0.20
- retrofit 2.9.0 -> 2.11.0

### 🎸 기타
- kotlinx-serialization-converter가 retrofit 자체 converter로 변경됨에 따라 해당 라이브러리로 교체