### PR TITLE
🔀 :: (#71) 뉴스 피드 뷰모델 및 UiState 구현

### DIFF
--- a/core/domain/src/main/java/com/skogkatt/domain/GetTranslatedEditorsPicksUseCase.kt
+++ b/core/domain/src/main/java/com/skogkatt/domain/GetTranslatedEditorsPicksUseCase.kt
@@ -10,12 +10,12 @@ class GetTranslatedEditorsPicksUseCase @Inject constructor(
     private val articleRepository: ArticleRepository,
     private val translationRepository: TranslationRepository,
 ) {
-    suspend operator fun invoke(): List<Article> {
+    suspend operator fun invoke(): Result<List<Article>> = runCatching {
         val editorsPicks = articleRepository.getEditorsPicks()
         val translation = Translation(editorsPicks.map(Article::title))
         val translatedTitles = translationRepository.translate(translation)
 
-        return editorsPicks.zip(translatedTitles) { editorsPick, translatedTitle ->
+        editorsPicks.zip(translatedTitles) { editorsPick, translatedTitle ->
             editorsPick.copy(title = translatedTitle)
         }
     }

--- a/feature/news-feed/build.gradle.kts
+++ b/feature/news-feed/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("alio.android.feature")
+    id("alio.android.hilt")
 }
 
 android {
@@ -20,8 +21,14 @@ android {
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:model"))
+    implementation(project(":core:domain"))
 
     implementation(libs.landscapist.glide)
+
+    implementation(libs.paging.runtime)
+    implementation(libs.paging.compose)
+
+    implementation(libs.hilt.navigation.compose)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedUiState.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedUiState.kt
@@ -1,0 +1,11 @@
+package com.skogkatt.news.feed
+
+import com.skogkatt.model.article.Article
+
+sealed interface NewsFeedUiState {
+    data object Loading : NewsFeedUiState
+
+    data class Error(val message: String?) : NewsFeedUiState
+
+    data class Success(val editorsPicks: List<Article>) : NewsFeedUiState
+}

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedViewModel.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedViewModel.kt
@@ -1,0 +1,53 @@
+package com.skogkatt.news.feed
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import com.skogkatt.domain.GetTranslatedArticlesUseCase
+import com.skogkatt.domain.GetTranslatedEditorsPicksUseCase
+import com.skogkatt.model.article.Article
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NewsFeedViewModel @Inject constructor(
+    private val getTranslatedEditorsPicksUseCase: GetTranslatedEditorsPicksUseCase,
+    private val getTranslatedArticlesUseCase: GetTranslatedArticlesUseCase,
+) : ViewModel() {
+    private val _newsFeedUiState = MutableStateFlow<NewsFeedUiState>(NewsFeedUiState.Loading)
+    val newsFeedUiState: StateFlow<NewsFeedUiState> = _newsFeedUiState.asStateFlow()
+
+    private val _latestArticles = MutableStateFlow<PagingData<Article>>(PagingData.empty())
+    val latestArticles: Flow<PagingData<Article>> = _latestArticles
+
+    fun refresh(section: String? = null) {
+        viewModelScope.launch {
+            getTranslatedEditorsPicks()
+            getTranslatedArticles(section)
+        }
+    }
+
+    private suspend fun getTranslatedEditorsPicks() {
+        getTranslatedEditorsPicksUseCase()
+            .onSuccess {
+                _newsFeedUiState.value = NewsFeedUiState.Success(it)
+            }
+            .onFailure {
+                _newsFeedUiState.value = NewsFeedUiState.Error(it.message)
+            }
+    }
+
+    private suspend fun getTranslatedArticles(section: String?) {
+        getTranslatedArticlesUseCase(section = section)
+            .cachedIn(viewModelScope)
+            .collect {
+                _latestArticles.value = it
+            }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kotlinxSerializationJson = "1.7.1"
 kotlin = "2.0.0"
 ktlint = "12.1.1"
 hilt = "2.51.1"
+hiltNavigation = "1.2.0"
 ksp = "2.0.0-1.0.23"
 
 okhttp = "4.12.0"
@@ -38,6 +39,7 @@ androidx-navigation = { group = "androidx.navigation", name = "navigation-compos
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigation" }
 hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
@@ -45,7 +47,7 @@ retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = 
 retrofit-kotlin-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
-paging-compose = { group = "androidx.paging", name = "paging-common", version.ref = "paging" }
+paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 landscapist-glide = { group = "com.github.skydoves", name = "landscapist-glide", version.ref = "landscapist" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
### 💡 개요
- 뉴스 피드 뷰모델 및 UiState 구현

### 📃 작업 내용
- NewsFeedViewModel 및 NewsFeedUiState 로직 구현
- GetTranslatedEditorsPicksUseCase에서 Result 타입으로 반환하도록 변경
- hilt-navigation-compose 추가 및 paging-compose name의 오탈자 수정
- AppBarHeight의 접근 제한자를 private로 변경

### 🎸 기타
- preview에서 사용되는 articles의 id 구분을 위해 임의로 넘버링 추가