### PR TITLE
🔀 :: (#74) API 로직 및 model 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/core/data/src/main/java/com/skogkatt/data/datasource/article/ArticleDataSource.kt
+++ b/core/data/src/main/java/com/skogkatt/data/datasource/article/ArticleDataSource.kt
@@ -1,13 +1,14 @@
 package com.skogkatt.data.datasource.article
 
+import com.skogkatt.network.model.Response
 import com.skogkatt.network.model.article.ArticleContentResponse
 import com.skogkatt.network.model.article.ArticleListResponse
 import com.skogkatt.network.model.article.EditorsPicksResponse
 
 internal interface ArticleDataSource {
-    suspend fun getArticles(page: Int, section: String?): ArticleListResponse
+    suspend fun getArticles(page: Int, section: String?): Response<ArticleListResponse>
 
-    suspend fun getArticleContent(id: String): ArticleContentResponse
+    suspend fun getArticleContent(id: String): Response<ArticleContentResponse>
 
-    suspend fun getEditorsPicks(): EditorsPicksResponse
+    suspend fun getEditorsPicks(): Response<EditorsPicksResponse>
 }

--- a/core/data/src/main/java/com/skogkatt/data/datasource/article/ArticleDataSourceImpl.kt
+++ b/core/data/src/main/java/com/skogkatt/data/datasource/article/ArticleDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.skogkatt.data.datasource.article
 
 import com.skogkatt.network.api.retrofit.GuardianApi
+import com.skogkatt.network.model.Response
 import com.skogkatt.network.model.article.ArticleContentResponse
 import com.skogkatt.network.model.article.ArticleListResponse
 import com.skogkatt.network.model.article.EditorsPicksResponse
@@ -12,18 +13,18 @@ internal class ArticleDataSourceImpl @Inject constructor(
     override suspend fun getArticles(
         page: Int,
         section: String?,
-    ): ArticleListResponse {
+    ): Response<ArticleListResponse> {
         return guardianApi.getArticles(
             page = page,
             section = section
         )
     }
 
-    override suspend fun getArticleContent(id: String): ArticleContentResponse {
+    override suspend fun getArticleContent(id: String): Response<ArticleContentResponse> {
         return guardianApi.getArticleById(id)
     }
 
-    override suspend fun getEditorsPicks(): EditorsPicksResponse {
+    override suspend fun getEditorsPicks(): Response<EditorsPicksResponse> {
         return guardianApi.getEditorsPicks()
     }
 }

--- a/core/data/src/main/java/com/skogkatt/data/model/translation/TranslationRequest.kt
+++ b/core/data/src/main/java/com/skogkatt/data/model/translation/TranslationRequest.kt
@@ -5,4 +5,6 @@ import com.skogkatt.network.model.translation.TranslationRequest
 
 internal fun Translation.toTranslationRequest() = TranslationRequest(
     texts = texts,
+    sourceLang = "EN",
+    targetLang = "KO",
 )

--- a/core/data/src/main/java/com/skogkatt/data/repository/article/ArticleRepositoryImpl.kt
+++ b/core/data/src/main/java/com/skogkatt/data/repository/article/ArticleRepositoryImpl.kt
@@ -28,7 +28,7 @@ internal class ArticleRepositoryImpl @Inject constructor(
                     articleDataSource.getArticles(
                         page = page,
                         section = section,
-                    )
+                    ).response
                 }
             },
         ).flow.map { pagingData ->
@@ -37,10 +37,10 @@ internal class ArticleRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getArticleContent(id: String): ArticleWithBodyText {
-        return articleDataSource.getArticleContent(id).articleContent.toArticleWithBodyText()
+        return articleDataSource.getArticleContent(id).response.articleContent.toArticleWithBodyText()
     }
 
     override suspend fun getEditorsPicks(): List<Article> {
-        return articleDataSource.getEditorsPicks().editorsPicks.map { it.toArticle() }
+        return articleDataSource.getEditorsPicks().response.editorsPicks.map { it.toArticle() }
     }
 }

--- a/core/network/src/main/java/com/skogkatt/network/api/retrofit/DeepLApi.kt
+++ b/core/network/src/main/java/com/skogkatt/network/api/retrofit/DeepLApi.kt
@@ -5,10 +5,10 @@ import com.skogkatt.network.api.ApiType
 import com.skogkatt.network.model.translation.TranslationRequest
 import com.skogkatt.network.model.translation.TranslationResponse
 import retrofit2.http.Body
-import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface DeepLApi {
-    @GET("v2/translate")
+    @POST("v2/translate")
     @Api(ApiType.DEEPL)
     suspend fun translate(
         @Body body: TranslationRequest

--- a/core/network/src/main/java/com/skogkatt/network/api/retrofit/GuardianApi.kt
+++ b/core/network/src/main/java/com/skogkatt/network/api/retrofit/GuardianApi.kt
@@ -2,6 +2,7 @@ package com.skogkatt.network.api.retrofit
 
 import com.skogkatt.network.api.Api
 import com.skogkatt.network.api.ApiType
+import com.skogkatt.network.model.Response
 import com.skogkatt.network.model.article.ArticleContentResponse
 import com.skogkatt.network.model.article.ArticleListResponse
 import com.skogkatt.network.model.article.EditorsPicksResponse
@@ -17,14 +18,14 @@ interface GuardianApi {
         @Query("section") section: String?,
         @Query("show-fields") showFields: String = "thumbnail",
         @Query("type") type: String = "article",
-    ): ArticleListResponse
+    ): Response<ArticleListResponse>
 
     @GET("{id}")
     @Api(ApiType.GUARDIAN)
     suspend fun getArticleById(
         @Path("id") id: String,
         @Query("show-fields") showFields: String = "bodyText,thumbnail",
-    ): ArticleContentResponse
+    ): Response<ArticleContentResponse>
 
     @GET("world")
     @Api(ApiType.GUARDIAN)
@@ -32,5 +33,5 @@ interface GuardianApi {
         @Query("show-editors-picks") showEditorsPicks: Boolean = true,
         @Query("show-fields") showFields: String = "thumbnail",
         @Query("type") type: String = "article",
-    ): EditorsPicksResponse
+    ): Response<EditorsPicksResponse>
 }

--- a/core/network/src/main/java/com/skogkatt/network/interceptor/ApiKeyInterceptor.kt
+++ b/core/network/src/main/java/com/skogkatt/network/interceptor/ApiKeyInterceptor.kt
@@ -30,7 +30,7 @@ internal class ApiKeyInterceptor : Interceptor {
                 newBuilder.url(newUrl)
             }
 
-            ApiType.DEEPL -> newBuilder.addHeader(name = "Authorization", value = apiKey)
+            ApiType.DEEPL -> newBuilder.addHeader(name = "Authorization", value = "DeepL-Auth-Key $apiKey")
         }
 
         return chain.proceed(newBuilder.build())

--- a/core/network/src/main/java/com/skogkatt/network/model/Response.kt
+++ b/core/network/src/main/java/com/skogkatt/network/model/Response.kt
@@ -1,0 +1,8 @@
+package com.skogkatt.network.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Response<T>(
+    val response: T
+)

--- a/core/network/src/main/java/com/skogkatt/network/model/article/ArticleContentResponse.kt
+++ b/core/network/src/main/java/com/skogkatt/network/model/article/ArticleContentResponse.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ArticleContentResponse(
-    val articleContent: ArticleWithBodyTextResponse,
+    @SerialName("content") val articleContent: ArticleWithBodyTextResponse,
 )
 
 @Serializable

--- a/core/network/src/main/java/com/skogkatt/network/model/article/EditorsPicksResponse.kt
+++ b/core/network/src/main/java/com/skogkatt/network/model/article/EditorsPicksResponse.kt
@@ -1,5 +1,8 @@
 package com.skogkatt.network.model.article
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class EditorsPicksResponse(
     val editorsPicks: List<ArticleResponse>
 )

--- a/core/network/src/main/java/com/skogkatt/network/model/translation/TranslationRequest.kt
+++ b/core/network/src/main/java/com/skogkatt/network/model/translation/TranslationRequest.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TranslationRequest(
     @SerialName("text") val texts: List<String>,
-    @SerialName("source_lang") val sourceLang: String = "EN",
-    @SerialName("target_lang") val targetLang: String = "KO",
+    @SerialName("source_lang") val sourceLang: String,
+    @SerialName("target_lang") val targetLang: String,
 )
 


### PR DESCRIPTION
### 💡 개요
- API 로직 및 model 수정

### 📃 작업 내용
- internet permission 추가
- DeepL api key 로직에 DeepL-Auth-Key prefix 추가
- `translate()`의 HTTP method를 GET에서 POST로 변경
- sourceLang 및 targetLang의 default value를 mapper에서 설정
- API 응답 처리를 위한 Response<T> wrapper 구현 및 적용
- ArticleContentResponse의 articleContent 프로퍼티에 SerialName annotation 추가