### PR TITLE
🔀 :: (#80) 뉴스 추가 로드가 되지 않는 오류 수정

### DIFF
--- a/core/data/src/main/java/com/skogkatt/data/paging/ArticlePagingSource.kt
+++ b/core/data/src/main/java/com/skogkatt/data/paging/ArticlePagingSource.kt
@@ -17,7 +17,7 @@ internal class ArticlePagingSource(
         return LoadResult.Page(
             data = response.articleResponses,
             prevKey = if (currentPage == StartingPage) null else currentPage - 1,
-            nextKey = if (currentPage >= response.currentPage) null else currentPage + 1,
+            nextKey = if (currentPage >= response.pageSize) null else currentPage + 1,
         )
     }
 

--- a/core/network/src/main/java/com/skogkatt/network/model/article/ArticleListResponse.kt
+++ b/core/network/src/main/java/com/skogkatt/network/model/article/ArticleListResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ArticleListResponse(
-    @SerialName("currentPage") val currentPage: Int,
+    @SerialName("pageSize") val pageSize: Int,
     @SerialName("results") val articleResponses: List<ArticleResponse>,
 )

--- a/core/network/src/main/java/com/skogkatt/network/model/article/ArticleResponse.kt
+++ b/core/network/src/main/java/com/skogkatt/network/model/article/ArticleResponse.kt
@@ -9,11 +9,11 @@ data class ArticleResponse(
     @SerialName("sectionId") val sectionId: String,
     @SerialName("webPublicationDate") val publishedAt: String,
     @SerialName("webTitle") val title: String,
-    @SerialName("fields") val fields: Fields,
+    @SerialName("fields") val fields: Fields = Fields(),
 ) {
     @Serializable
     data class Fields(
-        @SerialName("thumbnail") val thumbnailUrl: String,
+        @SerialName("thumbnail") val thumbnailUrl: String = "",
     )
 }
 


### PR DESCRIPTION
### 💡 개요
- 뉴스가 최초 로드 이후 추가 로드되지 않는 오류 수정

### 📃 작업 내용
- nextKey 로직에서 pageSize를 기준으로 설정하도록 수정
- thumbnail image가 없는 경우 처리를 위해 fields 및 thumbnailUrl의 default value 설정