### PR TITLE
🔀 :: (#127) 중복으로 적용된 hilt plugin 삭제

### DIFF
--- a/feature/news-feed/build.gradle.kts
+++ b/feature/news-feed/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("alio.android.feature")
-    id("alio.android.hilt")
 }
 
 android {


### PR DESCRIPTION
### 💡 개요
- 중복으로 적용된 hilt plugin 삭제

### 📃 작업 내용
- alio.android.feature 내부에 alio.android.hilt 플러그인이 포함되어 있어서 삭제