### PR TITLE
🔀 :: (#108) Google Cloud TTS 로직 변경

### DIFF
--- a/core/data/src/main/java/com/skogkatt/data/datasource/synthesis/SynthesisDataSource.kt
+++ b/core/data/src/main/java/com/skogkatt/data/datasource/synthesis/SynthesisDataSource.kt
@@ -1,7 +1,8 @@
 package com.skogkatt.data.datasource.synthesis
 
 import com.skogkatt.network.model.synthesis.SynthesisRequest
+import com.skogkatt.network.model.synthesis.SynthesisResponse
 
 internal interface SynthesisDataSource {
-    suspend fun synthesize(body: SynthesisRequest): String
+    suspend fun synthesize(body: SynthesisRequest): SynthesisResponse
 }

--- a/core/data/src/main/java/com/skogkatt/data/datasource/synthesis/SynthesisDataSourceImpl.kt
+++ b/core/data/src/main/java/com/skogkatt/data/datasource/synthesis/SynthesisDataSourceImpl.kt
@@ -2,12 +2,13 @@ package com.skogkatt.data.datasource.synthesis
 
 import com.skogkatt.network.api.retrofit.GoogleTTSApi
 import com.skogkatt.network.model.synthesis.SynthesisRequest
+import com.skogkatt.network.model.synthesis.SynthesisResponse
 import javax.inject.Inject
 
 internal class SynthesisDataSourceImpl @Inject constructor(
     private val googleTTSApi: GoogleTTSApi
 ) : SynthesisDataSource {
-    override suspend fun synthesize(body: SynthesisRequest): String {
+    override suspend fun synthesize(body: SynthesisRequest): SynthesisResponse {
         return googleTTSApi.synthesize(body)
     }
 }

--- a/core/data/src/main/java/com/skogkatt/data/repository/synthesis/SynthesisRepositoryImpl.kt
+++ b/core/data/src/main/java/com/skogkatt/data/repository/synthesis/SynthesisRepositoryImpl.kt
@@ -12,6 +12,6 @@ internal class SynthesisRepositoryImpl @Inject constructor(
     override suspend fun synthesize(body: Synthesis): ByteArray {
         val result = synthesisDataSource.synthesize(body.toSynthesisRequest())
         
-        return Base64.decode(result, Base64.DEFAULT)
+        return Base64.decode(result.audioContent, Base64.DEFAULT)
     }
 }

--- a/core/domain/src/main/java/com/skogkatt/domain/SynthesizeArticleContentUseCase.kt
+++ b/core/domain/src/main/java/com/skogkatt/domain/SynthesizeArticleContentUseCase.kt
@@ -8,10 +8,14 @@ class SynthesizeArticleContentUseCase @Inject constructor(
     private val synthesisRepository: SynthesisRepository,
     private val getTranslatedArticleContentUseCase: GetTranslatedArticleContentUseCase,
 ) {
-    suspend operator fun invoke(id: String, voice: String = "ko-KR-Neural2-B"): Result<ByteArray> {
+    suspend operator fun invoke(id: String, voice: String = "ko-KR-Neural2-B"): Result<List<ByteArray>> {
         return getTranslatedArticleContentUseCase(id).mapCatching { articleContent ->
-            val synthesis = Synthesis(text = articleContent.bodyText, voice = voice)
-            synthesisRepository.synthesize(synthesis)
+            val texts = articleContent.bodyText.split("\n\n")
+
+            texts.map { text ->
+                val synthesis = Synthesis(text = text, voice = voice)
+                synthesisRepository.synthesize(synthesis)
+            }
         }
     }
 }

--- a/core/domain/src/main/java/com/skogkatt/domain/SynthesizeContentToFileUseCase.kt
+++ b/core/domain/src/main/java/com/skogkatt/domain/SynthesizeContentToFileUseCase.kt
@@ -2,20 +2,23 @@ package com.skogkatt.domain
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileOutputStream
 import javax.inject.Inject
 
-// TODO: 추후 synthesizeLongAudio 로직으로 변경
 class SynthesizeContentToFileUseCase @Inject constructor(
     @ApplicationContext private val context: Context,
     private val synthesizeArticleContentUseCase: SynthesizeArticleContentUseCase,
 ) {
-//    suspend operator fun invoke(id: String, fileName: String = "audio.mp3"): Result<File> {
-//        return synthesizeArticleContentUseCase(id).mapCatching { byteArray ->
-//            val file = File(context.filesDir, fileName)
-//            FileOutputStream(file).use { fos ->
-//                fos.write(byteArray)
-//            }
-//            file
-//        }
-//    }
+    suspend operator fun invoke(id: String, fileName: String = "audio.mp3"): Result<List<File>> {
+        return synthesizeArticleContentUseCase(id).mapCatching { byteArrays ->
+            byteArrays.mapIndexed { index, byteArray ->
+                val file = File(context.filesDir, "$fileName$index")
+                FileOutputStream(file).use { fos ->
+                    fos.write(byteArray)
+                }
+                file
+            }
+        }
+    }
 }

--- a/core/network/src/main/java/com/skogkatt/network/api/retrofit/GoogleTTSApi.kt
+++ b/core/network/src/main/java/com/skogkatt/network/api/retrofit/GoogleTTSApi.kt
@@ -3,6 +3,7 @@ package com.skogkatt.network.api.retrofit
 import com.skogkatt.network.api.Api
 import com.skogkatt.network.api.ApiType
 import com.skogkatt.network.model.synthesis.SynthesisRequest
+import com.skogkatt.network.model.synthesis.SynthesisResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -11,5 +12,5 @@ interface GoogleTTSApi {
     @Api(ApiType.GOOGLE_TTS)
     suspend fun synthesize(
         @Body body: SynthesisRequest,
-    ): String
+    ): SynthesisResponse
 }

--- a/core/network/src/main/java/com/skogkatt/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/skogkatt/network/di/NetworkModule.kt
@@ -13,7 +13,6 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import javax.inject.Singleton
@@ -35,7 +34,6 @@ internal object NetworkModule {
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(apiKeyInterceptor)
         .addInterceptor(baseUrlInterceptor)
-        .addInterceptor(HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY })
         .build()
 
     @Provides

--- a/core/network/src/main/java/com/skogkatt/network/model/synthesis/SynthesisRequest.kt
+++ b/core/network/src/main/java/com/skogkatt/network/model/synthesis/SynthesisRequest.kt
@@ -3,7 +3,6 @@ package com.skogkatt.network.model.synthesis
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// TODO: 추후 synthesizeLongAudio 로직으로 변경
 @Serializable
 data class SynthesisRequest(
     val input: Input,

--- a/core/network/src/main/java/com/skogkatt/network/model/synthesis/SynthesisResponse.kt
+++ b/core/network/src/main/java/com/skogkatt/network/model/synthesis/SynthesisResponse.kt
@@ -1,0 +1,8 @@
+package com.skogkatt.network.model.synthesis
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SynthesisResponse(
+    val audioContent: String,
+)

--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailScreen.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailScreen.kt
@@ -2,14 +2,17 @@ package com.skogkatt.news.detail
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -20,7 +23,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.skogkatt.model.article.ArticleWithBodyText
 import com.skogkatt.ui.pretendard
-import java.io.File
 
 @Composable
 fun NewsDetailRoute(
@@ -29,17 +31,13 @@ fun NewsDetailRoute(
     modifier: Modifier = Modifier,
     viewModel: NewsDetailViewModel = hiltViewModel()
 ) {
-    val audioFile by viewModel.audioFile.collectAsStateWithLifecycle()
     val newsDetailUiState by viewModel.newsDetailUiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-//        TODO: 추후 synthesizeLongAudio 로직으로 변경
-        viewModel.getTranslatedArticleContent(id)
-//        viewModel.playSynthesizedAudio(id)
+        viewModel.refresh(id)
     }
 
     NewsDetailScreen(
-        audioFile = audioFile,
         newsDetailUiState = newsDetailUiState,
         navigateToBack = navigateToBack,
         modifier = modifier
@@ -48,7 +46,6 @@ fun NewsDetailRoute(
 
 @Composable
 internal fun NewsDetailScreen(
-    audioFile: File?,
     newsDetailUiState: NewsDetailUiState,
     navigateToBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -99,7 +96,15 @@ internal fun NewsDetailScreen(
         }
 
         is NewsDetailUiState.Error -> { }
-        NewsDetailUiState.Loading -> { }
+        NewsDetailUiState.Loading -> {
+            Box(
+                modifier = modifier.fillMaxSize()
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
     }
 }
 
@@ -162,7 +167,7 @@ private fun NewsDetailScreenPreview() {
     )
 
     NewsDetailScreen(
-        audioFile = null,
+//        audioFile = null,
         newsDetailUiState = NewsDetailUiState.Success(articleWithBodyText = content),
         navigateToBack = { },
     )

--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailViewModel.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailViewModel.kt
@@ -1,41 +1,52 @@
 package com.skogkatt.news.detail
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
 import com.skogkatt.domain.GetTranslatedArticleContentUseCase
+import com.skogkatt.domain.SynthesizeContentToFileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.io.File
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class NewsDetailViewModel @Inject constructor(
     private val getTranslatedArticleContentUseCase: GetTranslatedArticleContentUseCase,
-//    private val synthesizeContentToFileUseCase: SynthesizeContentToFileUseCase,
-//    private val exoPlayer: ExoPlayer,
+    private val synthesizeContentToFileUseCase: SynthesizeContentToFileUseCase,
+    private val exoPlayer: ExoPlayer,
 ) : ViewModel() {
     private val _newsDetailUiState = MutableStateFlow<NewsDetailUiState>(NewsDetailUiState.Loading)
     val newsDetailUiState: StateFlow<NewsDetailUiState> = _newsDetailUiState.asStateFlow()
 
-    private val _audioFile = MutableStateFlow<File?>(null)
-    val audioFile: StateFlow<File?> = _audioFile
+    fun refresh(id: String) {
+        viewModelScope.launch {
+            playSynthesizedAudio(id)
+            getTranslatedArticleContent(id)
+        }
+    }
 
-//    TODO: 추후 synthesizeLongAudio 로직으로 변경
-//    suspend fun playSynthesizedAudio(id: String) {
-//        synthesizeContentToFileUseCase(id)
-//            .onSuccess {
-//                val uri = Uri.fromFile(it)
-//                val mediaItem = MediaItem.fromUri(uri)
-//                exoPlayer.setMediaItem(mediaItem)
-//                exoPlayer.prepare()
-//            }
-//            .onFailure {
-//                _newsDetailUiState.value = NewsDetailUiState.Error(it.message)
-//            }
-//    }
+    private suspend fun playSynthesizedAudio(id: String) {
+        synthesizeContentToFileUseCase(id)
+            .onSuccess { files ->
+                val mediaItems = files.map {
+                    val uri = Uri.fromFile(it)
+                    MediaItem.fromUri(uri)
+                }
+                exoPlayer.setMediaItems(mediaItems)
+                exoPlayer.prepare()
+                exoPlayer.play()
+            }
+            .onFailure {
+                _newsDetailUiState.value = NewsDetailUiState.Error(it.message)
+            }
+    }
 
-    suspend fun getTranslatedArticleContent(id: String) {
+    private suspend fun getTranslatedArticleContent(id: String) {
         getTranslatedArticleContentUseCase(id)
             .onSuccess {
                 _newsDetailUiState.value = NewsDetailUiState.Success(it)
@@ -45,9 +56,8 @@ class NewsDetailViewModel @Inject constructor(
             }
     }
 
-//    TODO: 추후 synthesizeLongAudio 로직으로 변경
-//    override fun onCleared() {
-//        super.onCleared()
-//        exoPlayer.release()
-//    }
+    override fun onCleared() {
+        super.onCleared()
+        exoPlayer.release()
+    }
 }


### PR DESCRIPTION
### 💡 개요
- Google Cloud TTS 로직 변경

### 📃 작업 내용
- `synthesis()`의 응답으로 받는 dto 추가
- 개행(\n\n)마다 mp3로 변환해 exoplayer로 실행하도록 구현
- 불필요한 HttpLoggingInterceptor 삭제

### 🎸 기타
- 상세 페이지 로딩 속도 개선 필요