### PR TITLE
🔀 :: (#137) 문장 개행 로직 수정

### DIFF
--- a/core/domain/src/main/java/com/skogkatt/domain/GetTranslatedArticleContentUseCase.kt
+++ b/core/domain/src/main/java/com/skogkatt/domain/GetTranslatedArticleContentUseCase.kt
@@ -15,8 +15,7 @@ class GetTranslatedArticleContentUseCase @Inject constructor(
         val translation = Translation(listOf(articleContent.title, articleContent.bodyText))
         val (translatedTitle, translatedBodyText) = translationRepository.translate(translation)
 
-        // TODO: 문장 개행 로직 수정
-        val regex = Regex("""\.(?=")|\.""")
+        val regex = Regex("""\.(")|\.""")
 
         articleContent.copy(
             title = translatedTitle,


### PR DESCRIPTION
### 💡 개요
- 문장 개행 로직 수정

### 📃 작업 내용
- 정규 표현식에서 따옴표 전 마침표가 오는 경우를 잡지 못하는 문제 수정

### 🎸 기타
- 여러 줄 인용문인 경우 별도의 처리 필요
