### PR TITLE
🔀 :: (#135) MVI로 마이그레이션

### DIFF
--- a/app/src/main/java/com/skogkatt/alio/ALIONavHost.kt
+++ b/app/src/main/java/com/skogkatt/alio/ALIONavHost.kt
@@ -14,13 +14,20 @@ internal fun ALIONavHost(
     navController: NavHostController,
     modifier: Modifier = Modifier,
     startDestination: Route = Route.NewsFeed,
+    showSnackbar: (String?) -> Unit,
 ) {
     NavHost(
         navController = navController,
         startDestination = startDestination,
         modifier = modifier,
     ) {
-        newsFeedScreen(navigateToNewsDetail = navController::navigateToNewsDetail)
-        newsDetailScreen(navigateToBack = navController::popBackStack)
+        newsFeedScreen(
+            navigateToNewsDetail = navController::navigateToNewsDetail,
+            showSnackbar = showSnackbar
+        )
+        newsDetailScreen(
+            navigateToBack = navController::popBackStack,
+            showSnackbar = showSnackbar
+        )
     }
 }

--- a/app/src/main/java/com/skogkatt/alio/MainActivity.kt
+++ b/app/src/main/java/com/skogkatt/alio/MainActivity.kt
@@ -1,20 +1,41 @@
 package com.skogkatt.alio
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class MainActivity: ComponentActivity() {
+class MainActivity : ComponentActivity() {
+    @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
             val navController = rememberNavController()
+            val snackbarHostState = remember { SnackbarHostState() }
+            val coroutineScope = rememberCoroutineScope()
 
-            ALIONavHost(navController = navController)
+            Scaffold(
+                snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+            ) {
+                ALIONavHost(
+                    navController = navController,
+                    showSnackbar = {
+                        coroutineScope.launch {
+                            snackbarHostState.showSnackbar(it ?: "Unknown Error")
+                        }
+                    }
+                )
+            }
         }
     }
 }

--- a/build-logic/src/main/kotlin/alio.android.feature.gradle.kts
+++ b/build-logic/src/main/kotlin/alio.android.feature.gradle.kts
@@ -18,4 +18,7 @@ dependencies {
     implementation(project(":core:model"))
 
     implementation(libs.findLibrary("androidx-navigation").get())
+
+    implementation(libs.findLibrary("orbit-viewmodel").get())
+    implementation(libs.findLibrary("orbit-compose").get())
 }

--- a/core/domain/src/main/java/com/skogkatt/domain/GetTranslatedArticleContentUseCase.kt
+++ b/core/domain/src/main/java/com/skogkatt/domain/GetTranslatedArticleContentUseCase.kt
@@ -15,12 +15,12 @@ class GetTranslatedArticleContentUseCase @Inject constructor(
         val translation = Translation(listOf(articleContent.title, articleContent.bodyText))
         val (translatedTitle, translatedBodyText) = translationRepository.translate(translation)
 
-        val regex = Regex("""\.(")|\.""")
+        val regex = Regex("""\.(")|다\.""")
 
         articleContent.copy(
             title = translatedTitle,
             bodyText = translatedBodyText.replace(regex) {
-                if (it.value == ".\"") ".\"\n\n" else ".\n\n"
+                if (it.value == ".\"") ".\"\n\n" else "다.\n\n"
             }
         )
     }

--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailScreen.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.skogkatt.model.article.ArticleWithBodyText
+import com.skogkatt.news.detail.component.HeaderImage
 import com.skogkatt.ui.pretendard
 
 @Composable

--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailScreen.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailScreen.kt
@@ -20,19 +20,27 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.skogkatt.model.article.ArticleWithBodyText
 import com.skogkatt.news.detail.component.HeaderImage
 import com.skogkatt.ui.pretendard
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun NewsDetailRoute(
     id: String,
     navigateToBack: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: NewsDetailViewModel = hiltViewModel()
+    viewModel: NewsDetailViewModel = hiltViewModel(),
+    showSnackbar: (String?) -> Unit,
 ) {
-    val newsDetailUiState by viewModel.newsDetailUiState.collectAsStateWithLifecycle()
+    val newsDetailUiState by viewModel.collectAsState()
+
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is NewsDetailSideEffect.ShowSnackbar -> showSnackbar(sideEffect.error)
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.refresh(id)
@@ -51,58 +59,55 @@ internal fun NewsDetailScreen(
     navigateToBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    when (newsDetailUiState) {
-        is NewsDetailUiState.Success -> {
-            val content = newsDetailUiState.articleWithBodyText
+    val content = newsDetailUiState.articleWithBodyText
 
-            LazyColumn(
-                modifier = modifier
-                    .fillMaxSize()
-                    .background(color = Color(0xFFF8F8F8)),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                item {
-                    HeaderImage(
-                        imageUrl = content.thumbnailUrl,
-                        relativeTime = content.publishedAt,
-                        navigateToBack = navigateToBack,
-                    )
-                }
-
-                item {
-                    Text(
-                        text = content.title,
-                        modifier = Modifier.padding(horizontal = 20.dp),
-                        color = Color.Black,
-                        fontSize = 26.sp,
-                        fontWeight = FontWeight.Bold,
-                        fontFamily = pretendard,
-                    )
-                }
-
-                val paragraphs = content.bodyText.split("\n\n")
-
-                items(paragraphs) { paragraph ->
-                    Text(
-                        text = paragraph,
-                        modifier = Modifier.padding(horizontal = 20.dp),
-                        color = Color.Black,
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Medium,
-                        fontFamily = pretendard,
-                        lineHeight = 28.sp,
-                    )
-                }
-            }
+    if (newsDetailUiState.isLoading) {
+        Box(
+            modifier = modifier.fillMaxSize()
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center)
+            )
         }
+    }
 
-        is NewsDetailUiState.Error -> { }
-        NewsDetailUiState.Loading -> {
-            Box(
-                modifier = modifier.fillMaxSize()
-            ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.align(Alignment.Center)
+    if (content != null) {
+        LazyColumn(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = Color(0xFFF8F8F8)),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item {
+                HeaderImage(
+                    imageUrl = content.thumbnailUrl,
+                    relativeTime = content.publishedAt,
+                    navigateToBack = navigateToBack,
+                )
+            }
+
+            item {
+                Text(
+                    text = content.title,
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                    color = Color.Black,
+                    fontSize = 26.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = pretendard,
+                )
+            }
+
+            val paragraphs = content.bodyText.split("\n\n")
+
+            items(paragraphs) { paragraph ->
+                Text(
+                    text = paragraph,
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                    color = Color.Black,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    fontFamily = pretendard,
+                    lineHeight = 28.sp,
                 )
             }
         }
@@ -168,8 +173,7 @@ private fun NewsDetailScreenPreview() {
     )
 
     NewsDetailScreen(
-//        audioFile = null,
-        newsDetailUiState = NewsDetailUiState.Success(articleWithBodyText = content),
+        newsDetailUiState = NewsDetailUiState(),
         navigateToBack = { },
     )
 }

--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailSideEffect.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailSideEffect.kt
@@ -1,0 +1,5 @@
+package com.skogkatt.news.detail
+
+sealed class NewsDetailSideEffect {
+    data class ShowSnackbar(val error: String?) : NewsDetailSideEffect()
+}

--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailUiState.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailUiState.kt
@@ -2,10 +2,8 @@ package com.skogkatt.news.detail
 
 import com.skogkatt.model.article.ArticleWithBodyText
 
-sealed interface NewsDetailUiState {
-    data object Loading : NewsDetailUiState
-
-    data class Error(val message: String?) : NewsDetailUiState
-
-    data class Success(val articleWithBodyText: ArticleWithBodyText) : NewsDetailUiState
-}
+data class NewsDetailUiState(
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val articleWithBodyText: ArticleWithBodyText? = null,
+)

--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/component/HeaderImage.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/component/HeaderImage.kt
@@ -1,4 +1,4 @@
-package com.skogkatt.news.detail
+package com.skogkatt.news.detail.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/navigation/NewsDetailNavigation.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/navigation/NewsDetailNavigation.kt
@@ -13,13 +13,15 @@ fun NavController.navigateToNewsDetail(id: String) {
 
 fun NavGraphBuilder.newsDetailScreen(
     navigateToBack: () -> Unit,
+    showSnackbar: (String?) -> Unit,
 ) {
     composable<Route.NewsDetail> { navBackStackEntry ->
         val id = navBackStackEntry.toRoute<Route.NewsDetail>().id
 
         NewsDetailRoute(
             id = id,
-            navigateToBack = navigateToBack
+            navigateToBack = navigateToBack,
+            showSnackbar = showSnackbar
         )
     }
 }

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedScreen.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -47,6 +46,8 @@ import com.skogkatt.news.feed.component.NewsCard
 import com.skogkatt.ui.farnhamHeadline
 import com.skogkatt.ui.pretendard
 import kotlinx.coroutines.flow.flowOf
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 import kotlin.math.roundToInt
 
 private val AppBarHeight = 64.dp
@@ -55,10 +56,17 @@ private val AppBarHeight = 64.dp
 fun NewsFeedRoute(
     navigateToNewsDetail: (String) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: NewsFeedViewModel = hiltViewModel()
+    viewModel: NewsFeedViewModel = hiltViewModel(),
+    showSnackbar: (String?) -> Unit,
 ) {
-    val newsFeedUiState by viewModel.newsFeedUiState.collectAsStateWithLifecycle()
-    val latestArticles = viewModel.latestArticles.collectAsLazyPagingItems()
+    val newsFeedUiState by viewModel.collectAsState()
+    val latestArticles = newsFeedUiState.latestArticles.collectAsLazyPagingItems()
+
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is NewsFeedSideEffect.ShowSnackbar -> showSnackbar(sideEffect.error)
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.refresh()
@@ -94,127 +102,118 @@ internal fun NewsFeedScreen(
         }
     }
 
-    when (newsFeedUiState) {
-        is NewsFeedUiState.Success -> {
-            val pagerState = rememberPagerState(pageCount = { newsFeedUiState.editorsPicks.size })
+    val pagerState = rememberPagerState(pageCount = { newsFeedUiState.editorsPicks.size })
 
-            Box(
-                modifier = modifier
-                    .fillMaxSize()
-                    .nestedScroll(nestedScrollConnection)
-                    .background(color = Color(0xFFF8F8F8))
-            ) {
-                LazyColumn(
-                    contentPadding = PaddingValues(top = AppBarHeight),
-                    verticalArrangement = Arrangement.spacedBy(14.dp)
-                ) {
-                    item {
-                        Text(
-                            text = "에디터 추천",
-                            modifier = Modifier
-                                .padding(horizontal = 20.dp)
-                                .padding(top = 14.dp),
-                            color = Color.Black,
-                            fontSize = 24.sp,
-                            fontWeight = FontWeight.Bold,
-                            fontFamily = pretendard,
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .nestedScroll(nestedScrollConnection)
+            .background(color = Color(0xFFF8F8F8))
+    ) {
+        LazyColumn(
+            contentPadding = PaddingValues(top = AppBarHeight),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            item {
+                Text(
+                    text = "에디터 추천",
+                    modifier = Modifier
+                        .padding(horizontal = 20.dp)
+                        .padding(top = 14.dp),
+                    color = Color.Black,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = pretendard,
+                )
+            }
+
+            item {
+                if (newsFeedUiState.editorsPicks.isEmpty()) {
+                    Box(modifier = modifier.fillMaxWidth()) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.align(Alignment.Center)
                         )
-                    }
-
-                    item {
-                        HorizontalPager(
-                            state = pagerState,
-                            contentPadding = PaddingValues(horizontal = 20.dp),
-                            pageSize = PageSize.Fill,
-                            pageSpacing = 12.dp
-                        ) {
-                            val editorsPick = newsFeedUiState.editorsPicks[it]
-
-                            EditorPicksCard(
-                                title = editorsPick.title,
-                                relativeTime = editorsPick.publishedAt,
-                                imageUrl = editorsPick.thumbnailUrl,
-                                onClick = { navigateToNewsDetail(editorsPick.id) },
-                            )
-                        }
-                    }
-
-                    item {
-                        Text(
-                            text = "최근 뉴스",
-                            modifier = Modifier.padding(horizontal = 20.dp),
-                            fontSize = 24.sp,
-                            fontWeight = FontWeight.Bold,
-                            fontFamily = pretendard,
-                        )
-                    }
-
-                    item {
-                        if (latestArticles.itemCount == 0) {
-                            Box(
-                                modifier = modifier
-                                    .fillMaxWidth()
-                                    .align(Alignment.Center)
-                            ) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier
-                                        .align(Alignment.Center)
-                                )
-                            }
-                        }
-                    }
-
-                    items(
-                        count = latestArticles.itemCount,
-                        key = latestArticles.itemKey { it.id },
-                    ) {
-                        val latestArticle = latestArticles[it]
-
-                        if (latestArticle != null) {
-                            NewsCard(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 20.dp),
-                                title = latestArticle.title,
-                                relativeTime = latestArticle.publishedAt,
-                                imageUrl = latestArticle.thumbnailUrl,
-                                onClick = { navigateToNewsDetail(latestArticle.id) }
-                            )
-                        }
                     }
                 }
 
-                CenterAlignedTopAppBar(
-                    modifier = Modifier
-                        .offset { IntOffset(x = 0, y = appBarOffsetPx.floatValue.roundToInt()) }
-                        .drawBehind {
-                            drawLine(
-                                color = Color.Gray,
-                                start = Offset(x = 0f, y = size.height),
-                                end = Offset(x = size.width, y = size.height),
-                                strokeWidth = 2f
-                            )
-                        },
-                    title = {
-                        Text(
-                            text = "alio",
-                            color = Color.Black,
-                            fontSize = 28.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            fontFamily = farnhamHeadline,
+                HorizontalPager(
+                    state = pagerState,
+                    contentPadding = PaddingValues(horizontal = 20.dp),
+                    pageSize = PageSize.Fill,
+                    pageSpacing = 12.dp
+                ) {
+                    val editorsPick = newsFeedUiState.editorsPicks[it]
+
+                    EditorPicksCard(
+                        title = editorsPick.title,
+                        relativeTime = editorsPick.publishedAt,
+                        imageUrl = editorsPick.thumbnailUrl,
+                        onClick = { navigateToNewsDetail(editorsPick.id) },
+                    )
+                }
+            }
+
+            item {
+                Text(
+                    text = "최근 뉴스",
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = pretendard,
+                )
+            }
+
+            item {
+                if (latestArticles.itemCount == 0) {
+                    Box(modifier = modifier.fillMaxWidth()) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.align(Alignment.Center)
                         )
                     }
-                )
+                }
+            }
+
+            items(
+                count = latestArticles.itemCount,
+                key = latestArticles.itemKey { it.id },
+            ) {
+                val latestArticle = latestArticles[it]
+
+                if (latestArticle != null) {
+                    NewsCard(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp),
+                        title = latestArticle.title,
+                        relativeTime = latestArticle.publishedAt,
+                        imageUrl = latestArticle.thumbnailUrl,
+                        onClick = { navigateToNewsDetail(latestArticle.id) }
+                    )
+                }
             }
         }
 
-        is NewsFeedUiState.Error -> {
-            /* TODO: 에러 상태 처리 */
-        }
-
-        NewsFeedUiState.Loading -> {
-            /* TODO: Loading indicator 표시 */
-        }
+        CenterAlignedTopAppBar(
+            modifier = Modifier
+                .offset { IntOffset(x = 0, y = appBarOffsetPx.floatValue.roundToInt()) }
+                .drawBehind {
+                    drawLine(
+                        color = Color.Gray,
+                        start = Offset(x = 0f, y = size.height),
+                        end = Offset(x = size.width, y = size.height),
+                        strokeWidth = 2f
+                    )
+                },
+            title = {
+                Text(
+                    text = "alio",
+                    color = Color.Black,
+                    fontSize = 28.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = farnhamHeadline,
+                )
+            }
+        )
     }
 }
 
@@ -242,7 +241,7 @@ private fun NewsFeedScreenPreview() {
     }
 
     NewsFeedScreen(
-        newsFeedUiState = NewsFeedUiState.Success(editorsPicks = editorsPicks),
+        newsFeedUiState = NewsFeedUiState(editorsPicks = editorsPicks),
         latestArticles = flowOf(PagingData.from(articles)).collectAsLazyPagingItems(),
         navigateToNewsDetail = { },
     )

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedScreen.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedScreen.kt
@@ -42,6 +42,8 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import com.skogkatt.model.article.Article
+import com.skogkatt.news.feed.component.EditorPicksCard
+import com.skogkatt.news.feed.component.NewsCard
 import com.skogkatt.ui.farnhamHeadline
 import com.skogkatt.ui.pretendard
 import kotlinx.coroutines.flow.flowOf

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedSideEffect.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedSideEffect.kt
@@ -1,0 +1,5 @@
+package com.skogkatt.news.feed
+
+sealed class NewsFeedSideEffect {
+    data class ShowSnackbar(val error: String?) : NewsFeedSideEffect()
+}

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedUiState.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedUiState.kt
@@ -1,11 +1,12 @@
 package com.skogkatt.news.feed
 
+import androidx.paging.PagingData
 import com.skogkatt.model.article.Article
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
-sealed interface NewsFeedUiState {
-    data object Loading : NewsFeedUiState
-
-    data class Error(val message: String?) : NewsFeedUiState
-
-    data class Success(val editorsPicks: List<Article>) : NewsFeedUiState
-}
+data class NewsFeedUiState(
+    val editorsPicks: List<Article> = emptyList(),
+    val latestArticles: Flow<PagingData<Article>> = flow { PagingData.empty<Article>() },
+    val error: String? = null,
+)

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/component/EditorPicksCard.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/component/EditorPicksCard.kt
@@ -1,4 +1,4 @@
-package com.skogkatt.news.feed
+package com.skogkatt.news.feed.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/component/NewsCard.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/component/NewsCard.kt
@@ -1,4 +1,4 @@
-package com.skogkatt.news.feed
+package com.skogkatt.news.feed.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/navigation/NewsFeedNavigation.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/navigation/NewsFeedNavigation.kt
@@ -7,8 +7,12 @@ import com.skogkatt.news.feed.NewsFeedRoute
 
 fun NavGraphBuilder.newsFeedScreen(
     navigateToNewsDetail: (String) -> Unit,
+    showSnackbar: (String?) -> Unit
 ) {
     composable<Route.NewsFeed> {
-        NewsFeedRoute(navigateToNewsDetail = navigateToNewsDetail)
+        NewsFeedRoute(
+            navigateToNewsDetail = navigateToNewsDetail,
+            showSnackbar = showSnackbar
+        )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ androidxEspresso = "3.6.1"
 
 detekt = "1.23.7"
 
+orbit-mvi = "9.0.0"
+
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -62,6 +64,9 @@ androidx-test-ext = { group = "androidx.test.ext", name = "junit", version.ref =
 androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
+
+orbit-viewmodel = { group = "org.orbit-mvi", name = "orbit-viewmodel", version.ref = "orbit-mvi" }
+orbit-compose = { group = "org.orbit-mvi", name = "orbit-compose", version.ref = "orbit-mvi"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
### 💡 개요
- MVVM에서 MVI로 마이그레이션

### 📃 작업 내용
- orbit mvi dependency 추가 및 gradle convention plugin 작업
- component composable들을 별도의 폴더로 분리
- 문장 끝이 아닌데도 마침표에서 개행되던 오류 수정
- orbit mvi를 사용하는 방식으로 마이그레이션

### 🎸 기타
- tts 실행이 완료되기 전에 로딩 progress가 끝나는 버그가 있음