### PR TITLE
🔀 :: (#145) 읽어주는 문장에 맞게 자동으로 스크롤되는 기능 추가

### DIFF
--- a/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailViewModel.kt
+++ b/feature/news-detail/src/main/java/com/skogkatt/news/detail/NewsDetailViewModel.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
 class NewsDetailViewModel @Inject constructor(
     private val getTranslatedArticleContentUseCase: GetTranslatedArticleContentUseCase,
     private val synthesizeContentToFileUseCase: SynthesizeContentToFileUseCase,
-    private val exoPlayer: ExoPlayer,
+    val exoPlayer: ExoPlayer,
 ) : ContainerHost<NewsDetailUiState, NewsDetailSideEffect>, ViewModel() {
     override val container = container<NewsDetailUiState, NewsDetailSideEffect>(NewsDetailUiState())
 


### PR DESCRIPTION
### 💡 개요
- 현재 읽는 문장에 맞게 자동으로 스크롤되는 기능 구현

### 📃 작업 내용
- exoPlayer의 리스너를 추가하여 onMediaItemTransition 감지하도록 설정
- 감지된 이벤트에 따라 sentenceCount를 1씩 올리도록 구현

### 🎸 기타
- 리스너 내부에서 suspend function 사용이 불가능하여 viewmodel단이 아닌 screen에서 리스너를 등록함
- 추후 현재 재생되는 아이템의 순서나 id를 받아올 수 있는 경우 리팩토링 진행 필요