### PR TITLE
🔀 :: (#151) 상세 페이지 로직 개선

### DIFF
--- a/core/domain/src/main/java/com/skogkatt/domain/SynthesizeArticleContentUseCase.kt
+++ b/core/domain/src/main/java/com/skogkatt/domain/SynthesizeArticleContentUseCase.kt
@@ -15,15 +15,13 @@ class SynthesizeArticleContentUseCase @Inject constructor(
         articleWithBodyText: ArticleWithBodyText,
         voice: String = "ko-KR-Neural2-B"
     ): Result<List<ByteArray>> = runCatching {
-//        return getTranslatedArticleContentUseCase(id).mapCatching { articleContent ->
-            val texts = articleWithBodyText.bodyText.split("\n\n")
-            val results = coroutineScope {
-                texts.map { text ->
-                    val synthesis = Synthesis(text = text, voice = voice)
-                    async { synthesisRepository.synthesize(synthesis) }
-                }
+        val texts = articleWithBodyText.bodyText.split("\n\n")
+        val results = coroutineScope {
+            texts.map { text ->
+                val synthesis = Synthesis(text = text, voice = voice)
+                async { synthesisRepository.synthesize(synthesis) }
             }
-            results.awaitAll()
-//        }
+        }
+        results.awaitAll()
     }
 }

--- a/core/domain/src/main/java/com/skogkatt/domain/SynthesizeArticleContentUseCase.kt
+++ b/core/domain/src/main/java/com/skogkatt/domain/SynthesizeArticleContentUseCase.kt
@@ -1,6 +1,7 @@
 package com.skogkatt.domain
 
 import com.skogkatt.data.repository.synthesis.SynthesisRepository
+import com.skogkatt.model.article.ArticleWithBodyText
 import com.skogkatt.model.synthesis.Synthesis
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -9,11 +10,13 @@ import javax.inject.Inject
 
 class SynthesizeArticleContentUseCase @Inject constructor(
     private val synthesisRepository: SynthesisRepository,
-    private val getTranslatedArticleContentUseCase: GetTranslatedArticleContentUseCase,
 ) {
-    suspend operator fun invoke(id: String, voice: String = "ko-KR-Neural2-B"): Result<List<ByteArray>> {
-        return getTranslatedArticleContentUseCase(id).mapCatching { articleContent ->
-            val texts = articleContent.bodyText.split("\n\n")
+    suspend operator fun invoke(
+        articleWithBodyText: ArticleWithBodyText,
+        voice: String = "ko-KR-Neural2-B"
+    ): Result<List<ByteArray>> = runCatching {
+//        return getTranslatedArticleContentUseCase(id).mapCatching { articleContent ->
+            val texts = articleWithBodyText.bodyText.split("\n\n")
             val results = coroutineScope {
                 texts.map { text ->
                     val synthesis = Synthesis(text = text, voice = voice)
@@ -21,6 +24,6 @@ class SynthesizeArticleContentUseCase @Inject constructor(
                 }
             }
             results.awaitAll()
-        }
+//        }
     }
 }

--- a/core/domain/src/main/java/com/skogkatt/domain/SynthesizeContentToFileUseCase.kt
+++ b/core/domain/src/main/java/com/skogkatt/domain/SynthesizeContentToFileUseCase.kt
@@ -1,6 +1,7 @@
 package com.skogkatt.domain
 
 import android.content.Context
+import com.skogkatt.model.article.ArticleWithBodyText
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import java.io.FileOutputStream
@@ -10,8 +11,11 @@ class SynthesizeContentToFileUseCase @Inject constructor(
     @ApplicationContext private val context: Context,
     private val synthesizeArticleContentUseCase: SynthesizeArticleContentUseCase,
 ) {
-    suspend operator fun invoke(id: String, fileName: String = "audio.mp3"): Result<List<File>> {
-        return synthesizeArticleContentUseCase(id).mapCatching { byteArrays ->
+    suspend operator fun invoke(
+        articleWithBodyText: ArticleWithBodyText,
+        fileName: String = "audio.mp3"
+    ): Result<List<File>> {
+        return synthesizeArticleContentUseCase(articleWithBodyText).mapCatching { byteArrays ->
             byteArrays.mapIndexed { index, byteArray ->
                 val file = File(context.filesDir, "$fileName$index")
                 FileOutputStream(file).use { fos ->


### PR DESCRIPTION
### 💡 개요
- 상세 페이지 로직 개선

### 📃 작업 내용
- id를 통해 호출하는 방식에서 ArticleWithBodyText를 받는 방식으로 변경

### 🎸 기타
- api를 두 번 호출하는 문제는 해결되었으나 `getTranslatedArticleContent()`와 `playSynthesizedAudio()`의 결합도가 높아져 추후 해결 필요
