### PR TITLE
🔀 :: (#154) Navigation 처리를 SideEffect로 하도록 변경

### DIFF
--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedScreen.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedScreen.kt
@@ -61,6 +61,7 @@ fun NewsFeedRoute(
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             is NewsFeedSideEffect.ShowSnackbar -> showSnackbar(sideEffect.error)
+            is NewsFeedSideEffect.OnNewsClicked -> navigateToNewsDetail(sideEffect.id)
         }
     }
 
@@ -70,7 +71,7 @@ fun NewsFeedRoute(
 
     NewsFeedScreen(
         newsFeedUiState = newsFeedUiState,
-        navigateToNewsDetail = navigateToNewsDetail,
+        onNewsClicked = viewModel::onNewsClicked,
         modifier = modifier,
     )
 }
@@ -79,7 +80,7 @@ fun NewsFeedRoute(
 @Composable
 internal fun NewsFeedScreen(
     newsFeedUiState: NewsFeedUiState,
-    navigateToNewsDetail: (String) -> Unit,
+    onNewsClicked: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val latestArticles = newsFeedUiState.latestArticles.collectAsLazyPagingItems()
@@ -144,7 +145,7 @@ internal fun NewsFeedScreen(
                         title = editorsPick.title,
                         relativeTime = editorsPick.publishedAt,
                         imageUrl = editorsPick.thumbnailUrl,
-                        onClick = { navigateToNewsDetail(editorsPick.id) },
+                        onClick = { onNewsClicked(editorsPick.id) },
                     )
                 }
             }
@@ -183,7 +184,7 @@ internal fun NewsFeedScreen(
                         title = latestArticle.title,
                         relativeTime = latestArticle.publishedAt,
                         imageUrl = latestArticle.thumbnailUrl,
-                        onClick = { navigateToNewsDetail(latestArticle.id) }
+                        onClick = { onNewsClicked(latestArticle.id) }
                     )
                 }
             }
@@ -220,6 +221,6 @@ private fun NewsFeedScreenPreview(
 ) {
     NewsFeedScreen(
         newsFeedUiState = newsFeedUiState,
-        navigateToNewsDetail = { },
+        onNewsClicked = { },
     )
 }

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedSideEffect.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedSideEffect.kt
@@ -2,4 +2,5 @@ package com.skogkatt.news.feed
 
 sealed class NewsFeedSideEffect {
     data class ShowSnackbar(val error: String?) : NewsFeedSideEffect()
+    data class OnNewsClicked(val id: String): NewsFeedSideEffect()
 }

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedSideEffect.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedSideEffect.kt
@@ -2,5 +2,5 @@ package com.skogkatt.news.feed
 
 sealed class NewsFeedSideEffect {
     data class ShowSnackbar(val error: String?) : NewsFeedSideEffect()
-    data class OnNewsClicked(val id: String): NewsFeedSideEffect()
+    data class OnNewsClicked(val id: String) : NewsFeedSideEffect()
 }

--- a/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedViewModel.kt
+++ b/feature/news-feed/src/main/java/com/skogkatt/news/feed/NewsFeedViewModel.kt
@@ -23,6 +23,10 @@ class NewsFeedViewModel @Inject constructor(
         getTranslatedArticles(section)
     }
 
+    fun onNewsClicked(id: String) = intent {
+        postSideEffect(NewsFeedSideEffect.OnNewsClicked(id))
+    }
+
     private fun getTranslatedEditorsPicks() = intent {
         getTranslatedEditorsPicksUseCase()
             .onSuccess {


### PR DESCRIPTION
### 💡 개요
- Navigation 처리를 SideEffect로 하도록 변경

### 📃 작업 내용
- SideEffect에 OnNewsClicked를 추가하고, collectSideEffect에서 Navigation 처리

### 🎸 기타
- Navigation을 ViewModel에서 처리함으로써 비즈니스 결정을 내리지 않는 View를 만든다.
- 모든 비즈니스 로직을 한 곳에 둘 수 있어서 추후 유닛 테스트시 유리하다.